### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Android ChangeLog
 =================
 
+Version 2.0.1 March 15, 2018
+============================
+- Updated Gimbal SDK to 3.1.1
+
 Version 2.0.0 January 9, 2017
 =============================
 - Updated to Urban Airship SDK 8.9.6

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Urban Airship.
 
 To install it add the following dependency to your application's build.gradle file:
 ```
-   compile 'com.urbanairship.android:gimbal-adapter:2.0.0'
+   compile 'com.urbanairship.android:gimbal-adapter:2.0.1'
 ```
 
 ## Starting the adapter

--- a/gimbal-adapter/build.gradle
+++ b/gimbal-adapter/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.urbanairship.android'
-version = '2.0.0'
+version = '2.0.1'
 description = "Urban Airship Gimbal Adapter"
 
 apply plugin: 'com.android.library'
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation group:'com.gimbal.android.v3', name:'gimbal-sdk', version:'3.0'
+    implementation group:'com.gimbal.android.v3', name:'gimbal-sdk', version:'3.1.1'
     implementation group:'com.gimbal.android.v3', name:'gimbal-slf4j-impl', version:'3.0'
     implementation 'com.urbanairship.android:urbanairship-sdk:8.9.6'
 }

--- a/gimbal-adapter/src/main/java/com/urbanairship/gimbal/AirshipReadyReceiver.java
+++ b/gimbal-adapter/src/main/java/com/urbanairship/gimbal/AirshipReadyReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Urban Airship and Contributors
+ * Copyright 2018 Urban Airship and Contributors
  */
 
 package com.urbanairship.gimbal;

--- a/gimbal-adapter/src/main/java/com/urbanairship/gimbal/GimbalAdapter.java
+++ b/gimbal-adapter/src/main/java/com/urbanairship/gimbal/GimbalAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Urban Airship and Contributors
+ * Copyright 2018 Urban Airship and Contributors
  */
 
 package com.urbanairship.gimbal;
@@ -209,7 +209,7 @@ public class GimbalAdapter {
     @RequiresPermission(ACCESS_FINE_LOCATION)
     public boolean start(@NonNull String gimbalApiKey) {
         startAdapter(gimbalApiKey);
-        return Gimbal.isStarted();
+        return isStarted();
     }
 
     /**
@@ -294,7 +294,7 @@ public class GimbalAdapter {
      * Check if the adapter is started or not.
      */
     public boolean isStarted() {
-        return Gimbal.isStarted();
+        return isAdapterStarted && Gimbal.isStarted();
     }
 
     /**

--- a/gimbal-adapter/src/main/java/com/urbanairship/gimbal/GimbalAirshipReceiver.java
+++ b/gimbal-adapter/src/main/java/com/urbanairship/gimbal/GimbalAirshipReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Urban Airship and Contributors
+ * Copyright 2018 Urban Airship and Contributors
  */
 
 package com.urbanairship.gimbal;


### PR DESCRIPTION
- Bumps the Gimbal SDK to 3.1.1
- Added isAdapterStarted to isStarted() method to prevent hitting the Gimbal SDK before setting the API key
- Updated copyright headers
