### PR TITLE
MOBILE-[930] Handle Gimbal adapter crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 Android ChangeLog
 =================
 
+Version 4.0.0 - October 11, 2019
+================================
+- Updated Airship SDK to 11.0.3
+- Don't stop Gimbal if the adapter is not started.
+- Handle exception thrown when Gimbal.stop() is called when Gimbal is not started.
+
 Version 3.0.0 - June 21, 2019
 ==============================
 - Updated Airship SDK to 10.0.1
 - Updated Gimbal SDK to 4.0.1
-
 
 Version 2.2.0 - March 14, 2019
 ==============================

--- a/gimbal-adapter/build.gradle
+++ b/gimbal-adapter/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.urbanairship.android'
-version = '3.0.0'
+version = '4.0.0'
 description = "Urban Airship Gimbal Adapter"
 
 apply plugin: 'com.android.library'
@@ -23,7 +23,7 @@ android {
 dependencies {
     api 'com.gimbal.android.v4:gimbal-sdk:4.0.1'
     implementation 'com.gimbal.android.v4:gimbal-slf4j-impl:4.0.1'
-    api 'com.urbanairship.android:urbanairship-core:10.0.1'
+    api 'com.urbanairship.android:urbanairship-core:11.0.3'
 }
 
 // Create the pom configuration:

--- a/gimbal-adapter/src/main/java/com/urbanairship/gimbal/AirshipReadyReceiver.java
+++ b/gimbal-adapter/src/main/java/com/urbanairship/gimbal/AirshipReadyReceiver.java
@@ -7,7 +7,7 @@ package com.urbanairship.gimbal;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.urbanairship.UAirship;
 import com.urbanairship.push.RegistrationListener;

--- a/gimbal-adapter/src/main/java/com/urbanairship/gimbal/GimbalAdapter.java
+++ b/gimbal-adapter/src/main/java/com/urbanairship/gimbal/GimbalAdapter.java
@@ -10,10 +10,10 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.AsyncTask;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresPermission;
-import android.support.v4.content.ContextCompat;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
+import androidx.core.content.ContextCompat;
 import android.util.Log;
 
 import com.gimbal.android.DeviceAttributesManager;
@@ -21,6 +21,7 @@ import com.gimbal.android.Gimbal;
 import com.gimbal.android.PlaceEventListener;
 import com.gimbal.android.PlaceManager;
 import com.gimbal.android.Visit;
+import com.urbanairship.Logger;
 import com.urbanairship.UAirship;
 import com.urbanairship.location.RegionEvent;
 import com.urbanairship.util.DateUtils;
@@ -284,12 +285,22 @@ public class GimbalAdapter {
      * Stops the adapter.
      */
     public void stop() {
+        if (!isStarted()) {
+            Log.w(TAG, "stop() called when adapter was not started");
+            return;
+        }
+
         if (requestPermissionsTask != null) {
             requestPermissionsTask.cancel(true);
         }
 
-        Gimbal.stop();
-        PlaceManager.getInstance().removeListener(placeEventListener);
+        try {
+            Gimbal.stop();
+            PlaceManager.getInstance().removeListener(placeEventListener);
+        } catch (Exception e) {
+            Log.w(TAG,"Caught exception stopping Gimbal. ", e);
+        }
+
         isAdapterStarted = false;
 
         preferences.edit()

--- a/gimbal-adapter/src/main/java/com/urbanairship/gimbal/GimbalAdapter.java
+++ b/gimbal-adapter/src/main/java/com/urbanairship/gimbal/GimbalAdapter.java
@@ -297,7 +297,7 @@ public class GimbalAdapter {
         try {
             Gimbal.stop();
             PlaceManager.getInstance().removeListener(placeEventListener);
-        } catch (Exception e) {
+        } catch (java.lang.IllegalStateException e) {
             Log.w(TAG,"Caught exception stopping Gimbal. ", e);
         }
 


### PR DESCRIPTION
A developer reported an [NPE](https://github.com/urbanairship/android-gimbal-adapter/issues/12) when stopping the Gimbal adapter, perhaps without starting it first. I verified the the NPE does occur when I stopped the Gimbal adapter without first starting it. 

This PR adds the following code: 
- Don't try to stop the adapter if it is not started.
- Handle exception thrown when Gimbal.stop() is called when Gimbal is not started. (just in case)

I also updated to the current Airship SDK (11.0.3), so this is also Adapter release 4.0.0

I verified the solution by again stopping the Gimbal adapter without first starting it.