### PR TITLE
Release 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Android ChangeLog
 =================
 
+Version 4.1.1 - December 11, 2019
+=================================
+- Fixed null pointer exception due to updating Gimbal attributes if adapter is stopped.
+
 Version 4.1.0 - November 1, 2019
 ================================
 - Updated Airship SDK to 11.0.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Android ChangeLog
 
 Version 4.1.1 - December 11, 2019
 =================================
-- Fixed null pointer exception due to updating Gimbal attributes if adapter is stopped.
+- Fixed null pointer exception due to updating Gimbal attributes when the adapter is stopped.
 
 Version 4.1.0 - November 1, 2019
 ================================

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
 }

--- a/gimbal-adapter/build.gradle
+++ b/gimbal-adapter/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.urbanairship.android'
-version = '4.1.0'
+version = '4.1.1'
 description = "Urban Airship Gimbal Adapter"
 
 apply plugin: 'com.android.library'

--- a/gimbal-adapter/src/main/java/com/urbanairship/gimbal/AirshipReadyReceiver.java
+++ b/gimbal-adapter/src/main/java/com/urbanairship/gimbal/AirshipReadyReceiver.java
@@ -24,7 +24,7 @@ public class AirshipReadyReceiver extends BroadcastReceiver {
         UAirship.shared().getPushManager().addRegistrationListener(new RegistrationListener() {
             @Override
             public void onChannelCreated(@NonNull String channelId) {
-                GimbalAdapter.shared(context).updateDeviceAttributes();
+                GimbalAdapter.shared(context).onAirshipChannelCreated();
             }
 
             @Override

--- a/gimbal-adapter/src/main/java/com/urbanairship/gimbal/GimbalAdapter.java
+++ b/gimbal-adapter/src/main/java/com/urbanairship/gimbal/GimbalAdapter.java
@@ -21,7 +21,6 @@ import com.gimbal.android.Gimbal;
 import com.gimbal.android.PlaceEventListener;
 import com.gimbal.android.PlaceManager;
 import com.gimbal.android.Visit;
-import com.urbanairship.Logger;
 import com.urbanairship.UAirship;
 import com.urbanairship.location.RegionEvent;
 import com.urbanairship.util.DateUtils;
@@ -350,43 +349,48 @@ public class GimbalAdapter {
         return false;
     }
 
+    /**
+     * Called when the airship channel is created.
+     */
+    public void onAirshipChannelCreated() {
+        if (isStarted()) {
+            updateDeviceAttributes();
+        }
+    }
 
     /**
      * Updates Gimbal and Urban Airship device attributes.
      */
-    void updateDeviceAttributes() {
-        String gimbalApiKey = preferences.getString(API_KEY_PREFERENCE, null);
-        if (gimbalApiKey != null) {
+    private void updateDeviceAttributes() {
+        Map<String, String> deviceAttributes = new HashMap<>();
 
-            Map<String, String> deviceAttributes = new HashMap<>();
+        if (DeviceAttributesManager.getInstance().getDeviceAttributes() != null
+                && DeviceAttributesManager.getInstance().getDeviceAttributes().size() > 0) {
+            deviceAttributes.putAll(DeviceAttributesManager.getInstance().getDeviceAttributes());
+        }
 
-            if (DeviceAttributesManager.getInstance().getDeviceAttributes() != null
-                    && DeviceAttributesManager.getInstance().getDeviceAttributes().size() > 0) {
-                deviceAttributes.putAll(DeviceAttributesManager.getInstance().getDeviceAttributes());
-            }
+        String namedUserId = UAirship.shared().getNamedUser().getId();
+        if (namedUserId != null) {
+            deviceAttributes.put(GIMBAL_UA_NAMED_USER_ID, namedUserId);
+        } else {
+            deviceAttributes.remove(GIMBAL_UA_NAMED_USER_ID);
+        }
 
-            String namedUserId = UAirship.shared().getNamedUser().getId();
-            if (namedUserId != null) {
-                deviceAttributes.put(GIMBAL_UA_NAMED_USER_ID, namedUserId);
-            } else {
-                deviceAttributes.remove(GIMBAL_UA_NAMED_USER_ID);
-            }
+        String channelId = UAirship.shared().getPushManager().getChannelId();
+        if (channelId != null) {
+            deviceAttributes.put(GIMBAL_UA_CHANNEL_ID, channelId);
+        } else {
+            deviceAttributes.remove(GIMBAL_UA_CHANNEL_ID);
+        }
 
-            String channelId = UAirship.shared().getPushManager().getChannelId();
-            if (channelId != null) {
-                deviceAttributes.put(GIMBAL_UA_CHANNEL_ID, channelId);
-            } else {
-                deviceAttributes.remove(GIMBAL_UA_CHANNEL_ID);
-            }
+        DeviceAttributesManager deviceAttributesManager = DeviceAttributesManager.getInstance();
+        if (deviceAttributesManager != null && deviceAttributes.size() > 0) {
+            deviceAttributesManager.setDeviceAttributes(deviceAttributes);
+        }
 
-            if (deviceAttributes.size() > 0) {
-                DeviceAttributesManager.getInstance().setDeviceAttributes(deviceAttributes);
-            }
-
-            String gimbalInstanceId = Gimbal.getApplicationInstanceIdentifier();
-            if (gimbalInstanceId != null) {
-                UAirship.shared().getAnalytics().editAssociatedIdentifiers().addIdentifier(UA_GIMBAL_APPLICATION_INSTANCE_ID, gimbalInstanceId).apply();
-            }
+        String gimbalInstanceId = Gimbal.getApplicationInstanceIdentifier();
+        if (gimbalInstanceId != null) {
+            UAirship.shared().getAnalytics().editAssociatedIdentifiers().addIdentifier(UA_GIMBAL_APPLICATION_INSTANCE_ID, gimbalInstanceId).apply();
         }
     }
 

--- a/gimbal-adapter/src/main/java/com/urbanairship/gimbal/GimbalAdapter.java
+++ b/gimbal-adapter/src/main/java/com/urbanairship/gimbal/GimbalAdapter.java
@@ -364,9 +364,15 @@ public class GimbalAdapter {
     private void updateDeviceAttributes() {
         Map<String, String> deviceAttributes = new HashMap<>();
 
-        if (DeviceAttributesManager.getInstance().getDeviceAttributes() != null
-                && DeviceAttributesManager.getInstance().getDeviceAttributes().size() > 0) {
-            deviceAttributes.putAll(DeviceAttributesManager.getInstance().getDeviceAttributes());
+        DeviceAttributesManager deviceAttributesManager = DeviceAttributesManager.getInstance();
+
+        if (deviceAttributesManager == null) {
+            return;
+        }
+
+        if (deviceAttributesManager.getDeviceAttributes() != null
+                && deviceAttributesManager.getDeviceAttributes().size() > 0) {
+            deviceAttributes.putAll(deviceAttributesManager.getDeviceAttributes());
         }
 
         String namedUserId = UAirship.shared().getNamedUser().getId();
@@ -383,8 +389,7 @@ public class GimbalAdapter {
             deviceAttributes.remove(GIMBAL_UA_CHANNEL_ID);
         }
 
-        DeviceAttributesManager deviceAttributesManager = DeviceAttributesManager.getInstance();
-        if (deviceAttributesManager != null && deviceAttributes.size() > 0) {
+        if (deviceAttributes.size() > 0) {
             deviceAttributesManager.setDeviceAttributes(deviceAttributes);
         }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 21 20:08:32 CEST 2019
+#Wed Dec 11 11:49:30 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Adds additional checks before calling updateAttributes to prevent an NPE if gimbal is not started yet. The old check for checking for a previous key was not enough, I assume its from some sort of preference app restore that could get it into that state.