### PR TITLE
Release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Android ChangeLog
 =================
 
+Version 5.0.0 - January 9, 2020
+================================
+- Updated Airship SDK to 12.1.0
+
 Version 4.1.1 - December 11, 2019
 =================================
 - Fixed null pointer exception due to updating Gimbal attributes when the adapter is stopped.

--- a/gimbal-adapter/build.gradle
+++ b/gimbal-adapter/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.urbanairship.android'
-version = '4.1.1'
+version = '5.0.0'
 description = "Urban Airship Gimbal Adapter"
 
 apply plugin: 'com.android.library'
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
     }
 
     compileOptions {
@@ -23,7 +23,7 @@ android {
 dependencies {
     api 'com.gimbal.android.v4:gimbal-sdk:4.2.1'
     implementation 'com.gimbal.android.v4:gimbal-slf4j-impl:4.2.1'
-    api 'com.urbanairship.android:urbanairship-core:11.0.5'
+    api 'com.urbanairship.android:urbanairship-core:12.1.0'
 }
 
 // Create the pom configuration:

--- a/gimbal-adapter/src/main/java/com/urbanairship/gimbal/AirshipReadyReceiver.java
+++ b/gimbal-adapter/src/main/java/com/urbanairship/gimbal/AirshipReadyReceiver.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 
 import com.urbanairship.UAirship;
+import com.urbanairship.channel.AirshipChannelListener;
 import com.urbanairship.push.RegistrationListener;
 
 /**
@@ -21,7 +22,7 @@ public class AirshipReadyReceiver extends BroadcastReceiver {
     public void onReceive(final Context context, Intent intent) {
         GimbalAdapter.shared(context).restore();
 
-        UAirship.shared().getPushManager().addRegistrationListener(new RegistrationListener() {
+        UAirship.shared().getChannel().addChannelListener(new AirshipChannelListener() {
             @Override
             public void onChannelCreated(@NonNull String channelId) {
                 GimbalAdapter.shared(context).onAirshipChannelCreated();
@@ -29,11 +30,6 @@ public class AirshipReadyReceiver extends BroadcastReceiver {
 
             @Override
             public void onChannelUpdated(@NonNull String channelId) {
-            }
-
-            @Override
-            public void onPushTokenUpdated(@NonNull String token) {
-
             }
         });
     }


### PR DESCRIPTION
Gimbal adapter is currently not compatible with 12.1 because the named user package changed. If you try to use it with 12.1 you get a runtime exception. This rebuilds the adapter with latest SDK.