### PR TITLE
[MOBILE-1674] Gimbal Adapter 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Android Airship Gimbal Adapter ChangeLog
 
+## Version 7.0.0 - June 12, 2020
+- Removed gimbalApiKey parameters from start methods. Applications should set the API key directly
+  on the Gimbal instance in Application#onCreate or use the new `enableGimbalApiKeyManagement(String)`
+  method to allow the adapter to manage setting the Gimbal API key.
+  
 ## Version 6.1.0 - May 6, 2020
 - Updated Airship SDK to 13.1.0
 - Added missing nullability annotations

--- a/README.md
+++ b/README.md
@@ -12,14 +12,33 @@ Urban Airship.
 
 To install it add the following dependency to your application's build.gradle file:
 ```
-   implementation 'com.urbanairship.android:gimbal-adapter:6.0.0'
+   implementation 'com.urbanairship.android:gimbal-adapter:6.2.0'
 ```
 
-## Starting the adapter
+## Set the Gimbal API key
+
+Set the API key during Application#onCreate:
+```
+   Gimbal.setApiKey(this, "## PLACE YOUR API KEY HERE ##");
+```
+
+Alternatively you can have the adapter automatically persist and set the API key on Gimbal when
+the app starts:
+```
+   GimbalAdapter.shared(context).enableGimbalApiKeyManagement("## PLACE YOUR API KEY HERE ##");
+```
+
+To stop this behavior, you will need to disable it:
+```
+   GimbalAdapter.shared(context).disableGimbalApiKeyManagement();
+```
+
+
+## Start the adapter
 
 To start the adapter call:
 ```
-   GimbalAdapter.shared(context).start("## PLACE YOUR API KEY HERE ##");
+   GimbalAdapter.shared(context).start();
 ```
 
 Once the adapter is started, it will automatically resume its last state if
@@ -32,7 +51,7 @@ Before the adapter is able to be started on Android M, it must request the locat
 ``ACCESS_FINE_LOCATION``. The adapter has convenience methods that you can use to request permissions while
 starting the adapter:
 ```
-    GimbalAdapter.shared(context).startWithPermissionPrompt("## PLACE YOUR API KEY HERE ##", new GimbalAdapter.PermissionResultCallback() {
+    GimbalAdapter.shared(context).startWithPermissionPrompt(new GimbalAdapter.PermissionResultCallback() {
         @Override
         public void onResult(boolean enabled) {
             if (enabled) {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        adapterVersion = '6.1.0'
+        adapterVersion = '7.0.0'
 
         // Dependencies
         airshipVersion = '13.1.0'


### PR DESCRIPTION
Main change is to break apart setting the gimbal API key when starting the adapter. Gimbal has other features that you might want to use before starting the adapter like GDPR consent.

It could still be useful to have the adapter manage the API key for the app, so I added a path forward for apps that want that behavior with new enable/disableGimbalApiKeyManagement methods.